### PR TITLE
Ensure the ambientPressure variable is initialized

### DIFF
--- a/rocotest.ino
+++ b/rocotest.ino
@@ -33,7 +33,7 @@ struct compressionRecord
 
 typedef struct compressionRecord CompressionRecord;
 
-float ambientPressure;
+float ambientPressure = 0.0f;
 
 void setup() {
   Serial.begin(9600);


### PR DESCRIPTION
Previously, the variable 'ambientPressure' was not initialized, which potentially could lead to unpredictable behavior or incorrect results based on the random initial value. This commit initializes 'ambientPressure' to zero ensuring a consistent starting state and preventing any such issues.